### PR TITLE
Fix protopb CI build errors

### DIFF
--- a/.github/workflows/ci-dispatch.yml
+++ b/.github/workflows/ci-dispatch.yml
@@ -1,0 +1,18 @@
+name: CI Dispatch
+
+on:
+  workflow_dispatch:
+    inputs:
+      sming_repo:
+        description: 'Full URL for Sming repository'
+        default: 'https://github.com/SmingHub/Sming'
+      sming_branch:
+        description: 'Sming branch to run against'
+        default: 'develop'
+
+jobs:
+  build:
+    uses: SmingHub/Sming/.github/workflows/library.yml@develop
+    with:
+      sming_repo: ${{ inputs.sming_repo }}
+      sming_branch: ${{ inputs.sming_branch }}

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -1,0 +1,12 @@
+name: CI Push
+
+on:
+  push:
+    branches:
+    - develop
+  pull_request:
+
+
+jobs:
+  build:
+    uses: SmingHub/Sming/.github/workflows/library.yml@develop

--- a/component.mk
+++ b/component.mk
@@ -9,11 +9,11 @@ COMPONENT_DEPENDS := \
 # Google Cast requires SSL for communication. Add this to project configuration.
 # ENABLE_SSL = Bearssl
 
+GOOGLECAST_PATH := $(COMPONENT_PATH)
 
 ##@Building
+
 .PHONY: rebuild-cast-proto
-
-$(COMPONENT_PATH)/proto/cast_channel.pb.%: $(COMPONENT_PATH)/proto/cast_channel.proto
-	$(Q) cd $(dir $<) && $(PYTHON) $(SMING_HOME)/Libraries/nanopb/nanopb/generator/nanopb_generator.py cast_channel.proto
-
-rebuild-cast-proto: $(COMPONENT_PATH)/proto/cast_channel.pb.c ##Rebuild the generated C and H files from the google-cast protocol
+rebuild-cast-proto: ##Rebuild the generated C and H files from the google-cast protocol
+	echo "$(NANOPB_GENERATE) cast_channel.proto"
+	$(Q) cd $(GOOGLECAST_PATH)/proto && $(NANOPB_GENERATE) cast_channel.proto


### PR DESCRIPTION
CI builds fail perodically with

```
Traceback (most recent call last):
  File "/home/runner/work/Sming/Sming/Sming/Libraries/nanopb/nanopb/generator/nanopb_generator.py", line 51, in <module>
    from .proto import nanopb_pb2
ImportError: attempted relative import with no known parent package

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/work/Sming/Sming/Sming/Libraries/nanopb/nanopb/generator/nanopb_generator.py", line 72, in <module>
    import proto.nanopb_pb2 as nanopb_pb2
  File "/home/runner/work/Sming/Sming/Sming/Libraries/nanopb/nanopb/generator/proto/__init__.py", line 7, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

Looking at `component.mk`, the `nanopb_generator.py` script shouldn't be called at all because the required .h and .c files already exist. What I suspect is happening is that during git checkout, the `.proto` file timestamp differs from the .h and .c files and thus causes an attempted rebuild.

So the question becomes: is it the intention that the .c and .h files are rebuilt in this way? Since these are part of the repository it seems more logical that these should only be rebuilt on request.

Also `COMPONENT_PATH` must not be used directly in a build as it's value does not persist. See note here https://sming.readthedocs.io/en/latest/_inc/Sming/building.html#envvar-COMPONENT_CPPFLAGS.

Here, I've replaced the hard-coded path to `nanopb_generator.py` with a `NANOPB_GENERATE` macro in the `nanopb` library:

```
diff --git a/Sming/Libraries/nanopb/component.mk b/Sming/Libraries/nanopb/component.mk
index 28bb9259e..61a697201 100644
--- a/Sming/Libraries/nanopb/component.mk
+++ b/Sming/Libraries/nanopb/component.mk
@@ -1,4 +1,6 @@
 COMPONENT_SRCDIRS := nanopb src
 COMPONENT_INCDIRS := nanopb src/include
 
-COMPONENT_SUBMODULES += nanopb
\ No newline at end of file
+COMPONENT_SUBMODULES += nanopb
+
+NANOPB_GENERATE := $(PYTHON) $(COMPONENT_PATH)/nanopb/generator/nanopb_generator.py
```

When this PR is merged I'll raise a PR for that to Sming, including the updated `GoogleCast` library.
