### PR TITLE
Fix CI build, requires library alias

### DIFF
--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -3,10 +3,12 @@ name: CI Push
 on:
   push:
     branches:
-    - develop
+    - main
   pull_request:
 
 
 jobs:
   build:
     uses: SmingHub/Sming/.github/workflows/library.yml@develop
+    with:
+      alias: GoogleCast


### PR DESCRIPTION
Otherwise just builds branch contained in Sming. Also there is no develop branch! (It's the github default `main`)